### PR TITLE
feat: 관리자 페이지 연동, css 개선, UX 흐름 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1387,6 +1388,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1428,6 +1430,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1550,6 +1553,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1864,6 +1868,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2713,6 +2718,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2780,6 +2786,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3010,6 +3017,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3131,6 +3139,7 @@
       "integrity": "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview --host"
   },
   "dependencies": {
     "axios": "^1.13.2",

--- a/src/Styles/check-modal.css
+++ b/src/Styles/check-modal.css
@@ -31,13 +31,23 @@
 }
 
 /* ===== 예약자 입력 ===== */
+
+.check-input-div{
+  width: 100%;
+  display: flex;
+  /* justify-content: center; */
+}
+
 .check-input {
   width: 100%;
-  max-width: 160px;
-  padding: 10px 12px;
+  height: 32px;
+  padding: 0px 12px;
   border-radius: 12px;
   border: 2px solid #facc15;
   background: #fffbea;
+  font-size: 14px;
+  color: #0f172a;
+  font-weight: 500;
 }
 
 /* ===== PIN ===== */
@@ -101,6 +111,7 @@
   font-family: "GmarketMedium";
   cursor: pointer;
   display: block;
+  margin-top: 16px;
 }
 
 /* 결과 버튼 */
@@ -183,15 +194,19 @@
 
 /* 상세에서 읽기 전용 박스 */
 .readonly {
+  display: flex;
+  align-items: center;
   width: 100%;
-  max-width: 220px;
-  margin: 0 0 8px 0;
-  padding: 10px 12px;
+  height: 32px;
+  max-width: 100vw;
+  padding: 0px 12px;
   border-radius: 12px;
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
-  text-align: center;
-  font-family: "GmarketMedium";
+  border: 2px solid #facc15;
+  background: #fffbea;
+
+  font-size: 14px;
+  color: #0f172a;
+  font-weight: 500;
 }
 
 

--- a/src/Styles/layout.css
+++ b/src/Styles/layout.css
@@ -80,9 +80,8 @@
 /* 공지 박스 */
 .notice-box {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   gap: 16px;
-  align-items: center;
   padding: 10px 14px;
   border: 2px solid #facc15;
   border-radius: 12px;
@@ -91,6 +90,19 @@
   color: #374151;
   max-width: 360px;
   margin: 0 auto;
+  text-align: left;
+  font-size: 15px;
+}
+
+.notice-box-div {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  text-align: left;
+  font-size: 12px;
+}
+.notice-span {
+  margin-bottom: 2px;
 }
 
 .notice-box-span2 {

--- a/src/api/reservationApi.js
+++ b/src/api/reservationApi.js
@@ -35,3 +35,36 @@ export async function deleteReservation({ date, slot, room, password }) {
   });
   return res.data;
 }
+
+// ================  관리자용 ================
+
+// 관리자 로그인
+export async function adminLogin({ name, password }) {
+  const res = await client.post("/admin/login", { name, password });
+  return res.data; // { role: "admin", token: "..." }
+}
+
+// 관리자 슬롯 전체 조회
+export async function adminReadAll({ date, slot, token }) {
+  const res = await client.get("/admin/reservations", {
+    params: { date, slot },
+    headers: { "X-Admin-Token": String(token ?? "") },
+  });
+  return res.data;
+}
+
+// 관리자 강제 취소
+export async function adminForceDelete({ date, slot, room, token }) {
+  const res = await client.delete(`/admin/reservations/${date}/${slot}/${room}`, {
+    headers: { "X-Admin-Token": String(token ?? "") },
+  });
+  return res.data;
+}
+
+// 관리자 해당 회의실 조회
+export async function adminReadRoom({ date, room, token }) {
+  const res = await client.get(`/admin/rooms/${date}/${room}`, {
+    headers: { "X-Admin-Token": token },
+  });
+  return res.data; // part1~part8 중 예약 있는 것만(또는 8개 전부)
+}

--- a/src/components/AdminModal.jsx
+++ b/src/components/AdminModal.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import "../styles/admin-modal.css";
 import RoomDropdown from "./RoomDropdown";
+import { adminReadAll, adminForceDelete } from "../api/reservationApi"; // ✅ 바꿈
 
 const ROOMS = [
   "회의실 1",
@@ -12,112 +13,142 @@ const ROOMS = [
   "회의실 7",
 ];
 
-const SLOT_SEED = [
-  {
-    id: 1,
-    time: "08:00 - 09:00",
-    used: true,
-    badge: "호날두",
-    name: "호날두",
-    course: "웹/앱",
-    gen: 3,
-    head: 4,
-  },
-  {
-    id: 2,
-    time: "09:00 - 11:00",
-    used: true,
-    badge: "산체스",
-    name: "산체스",
-    course: "클라우드",
-    gen: 2,
-    head: 3,
-  },
-  {
-    id: 3,
-    time: "11:00 - 13:00",
-    used: true,
-    badge: "달롯",
-    name: "달롯",
-    course: "보안",
-    gen: 1,
-    head: 2,
-  },
-  { id: 4, time: "13:00 - 14:00", used: false, badge: "미사용" },
-  { id: 5, time: "14:00 - 16:00", used: false, badge: "미사용" },
-  {
-    id: 6,
-    time: "16:00 - 18:00",
-    used: true,
-    badge: "브페",
-    name: "브루노",
-    course: "웹/앱",
-    gen: 3,
-    head: 4,
-  },
-  { id: 7, time: "18:00 - 20:00", used: false, badge: "미사용" },
-  {
-    id: 8,
-    time: "20:00 - 21:00",
-    used: true,
-    badge: "박지성",
-    name: "박지성",
-    course: "웹/앱",
-    gen: 3,
-    head: 5,
-  },
+const SLOT_META = [
+  { id: 1, slot: "part1", time: "08:00 - 09:00" },
+  { id: 2, slot: "part2", time: "09:00 - 11:00" },
+  { id: 3, slot: "part3", time: "11:00 - 13:00" },
+  { id: 4, slot: "part4", time: "13:00 - 14:00" },
+  { id: 5, slot: "part5", time: "14:00 - 16:00" },
+  { id: 6, slot: "part6", time: "16:00 - 18:00" },
+  { id: 7, slot: "part7", time: "18:00 - 20:00" },
+  { id: 8, slot: "part8", time: "20:00 - 21:00" },
 ];
 
-const AdminModal = ({ open, onClose, onForceCancel }) => {
+const AdminModal = ({ open, onClose, token }) => {
+  // ✅ token 받기
   const [room, setRoom] = useState(ROOMS[0]);
-  const [selectedId, setSelectedId] = useState(6);
+  const [selectedId, setSelectedId] = useState(1);
 
-  const slots = useMemo(() => SLOT_SEED, []);
+  const [slots, setSlots] = useState(
+    SLOT_META.map((s) => ({ ...s, used: false, badge: "미사용", _raw: null }))
+  );
+
   const selected = useMemo(
     () => slots.find((s) => s.id === selectedId),
     [slots, selectedId]
   );
 
   const [name, setName] = useState("");
-  const [course, setCourse] = useState("웹/앱");
-  const [gen, setGen] = useState(1);
+  const [course, setCourse] = useState("");
   const [head, setHead] = useState(1);
 
+  const date = useMemo(() => {
+    return new Intl.DateTimeFormat("sv-SE", {
+      timeZone: "Asia/Seoul",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date());
+  }, []);
+
+  const roomNo = useMemo(() => String(ROOMS.indexOf(room) + 1), [room]);
+
+  // ✅ 슬롯 8개 조회 (slot마다 readAll 1번) -> roomNo만 골라서 표시
+  useEffect(() => {
+    if (!open) return;
+    if (!token) return; // ✅ 토큰 없으면 조회 금지
+
+    const fetchSlots = async () => {
+      const results = await Promise.all(
+        SLOT_META.map(async (s) => {
+          try {
+            const list = await adminReadAll({ date, slot: s.slot, token }); // ✅ readAll
+
+            // list: [{date, slot, room, reservation:{...}}, ...]
+            const found = (list ?? []).find((x) => String(x.room) === roomNo);
+
+            if (!found || !found.reservation) {
+              return { ...s, used: false, badge: "미사용", _raw: null };
+            }
+
+            return {
+              ...s,
+              used: true,
+              badge: found.reservation.name ?? "사용중",
+              _raw: found,
+            };
+          } catch (e) {
+            console.error(e);
+            return { ...s, used: false, badge: "미사용", _raw: null };
+          }
+        })
+      );
+
+      setSlots(results);
+
+      const cur = results.find((x) => x.id === selectedId);
+      if (!cur?.used) {
+        const firstUsed = results.find((x) => x.used);
+        setSelectedId(firstUsed ? firstUsed.id : 1);
+      }
+    };
+
+    fetchSlots();
+  }, [open, roomNo, token, date, selectedId]);
+
+  // ✅ 선택된 슬롯 상세 반영
   useEffect(() => {
     if (!open) return;
 
-    const handler = (e) => e.key === "Escape" && onClose?.();
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [open, onClose]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    if (!selected || !selected.used) {
+    if (!selected?.used || !selected?._raw) {
       setName("");
-      setCourse("웹/앱");
-      setGen(1);
+      setCourse("");
       setHead(1);
       return;
     }
-    setName(selected.name ?? "");
-    setCourse(selected.course ?? "웹/앱");
-    setGen(selected.gen ?? 1);
-    setHead(selected.head ?? 1);
+
+    setName(selected._raw.reservation?.name ?? "");
+    setCourse(selected._raw.reservation?.course ?? "");
+    setHead(selected._raw.reservation?.headcount ?? 1);
   }, [open, selected]);
 
   if (!open) return null;
 
-  const handleForceCancel = () => {
+  const handleForceCancel = async () => {
     if (!selected?.used) return;
-    onForceCancel?.({ room, slotId: selected.id });
+    if (!token) {
+      alert("관리자 토큰이 없습니다. 다시 로그인해주세요.");
+      return;
+    }
+
+    try {
+      await adminForceDelete({
+        date,
+        slot: selected.slot,
+        room: roomNo,
+        token,
+      });
+
+      // ✅ 취소 후: 현재 슬롯 상태만 즉시 갱신(간단 버전)
+      setSlots((prev) =>
+        prev.map((s) =>
+          s.id === selected.id
+            ? { ...s, used: false, badge: "미사용", _raw: null }
+            : s
+        )
+      );
+      setName("");
+      setCourse("");
+      setHead(1);
+    } catch (e) {
+      console.error(e);
+      alert("강제 취소 실패 (토큰/서버 확인)");
+    }
   };
 
   return (
     <div className="admin-backdrop" onClick={onClose}>
       <div className="admin-modal" onClick={(e) => e.stopPropagation()}>
-        {/* ✅ 헤더 */}
         <div className="admin-header">
           <div className="admin-title">관리자 조회</div>
           <button className="admin-close" onClick={onClose} aria-label="close">
@@ -127,7 +158,6 @@ const AdminModal = ({ open, onClose, onForceCancel }) => {
 
         <div className="admin-divider" />
 
-        {/* ✅ 바디(여기만 스크롤) */}
         <div className="admin-body">
           <RoomDropdown value={room} options={ROOMS} onChange={setRoom} />
 
@@ -171,11 +201,6 @@ const AdminModal = ({ open, onClose, onForceCancel }) => {
               <div className="admin-label">해당 반</div>
               <input className="admin-input" value={course} readOnly />
             </div>
-
-            {/* <div className="admin-row">
-              <div className="admin-label">기수</div>
-              <input className="admin-input" value={`${gen}기`} readOnly />
-            </div> */}
 
             <div className="admin-row">
               <div className="admin-label">인원 수</div>

--- a/src/components/ReservationDetailModal.jsx
+++ b/src/components/ReservationDetailModal.jsx
@@ -3,215 +3,234 @@ import Modal from "./Modal";
 import "../styles/form-modal.css";
 import "../styles/reservation.css";
 
-const ReservationDetailModal = ({ reservation, onClose, onUpdate, onCancel }) => {
-    const [name, setName] = useState("");
-    const [count, setCount] = useState(4);
-    const [classType, setClassType] = useState(null);
-    const [pin, setPin] = useState(["", "", "", ""]);
-    const pinRefs = useRef([]);
+const ReservationDetailModal = ({
+  reservation,
+  onClose,
+  onUpdate,
+  onCancel,
+}) => {
+  const [name, setName] = useState("");
+  const [count, setCount] = useState(4);
+  const [classType, setClassType] = useState(null);
+  const [pin, setPin] = useState(["", "", "", ""]);
+  const pinRefs = useRef([]);
 
-    // ✅ 추가
-    const [isSaving, setIsSaving] = useState(false);
-    const [savedToast, setSavedToast] = useState(false);
-    const closeTimerRef = useRef(null);
+  // ✅ 추가
+  const [isSaving, setIsSaving] = useState(false);
+  const [savedToast, setSavedToast] = useState(false);
+  const closeTimerRef = useRef(null);
 
-    const classes = ["임베디드", "클라우드", "웹/앱", "스마트팩토리", "IT/보안"];
+  const classes = ["임베디드", "클라우드", "웹/앱", "스마트팩토리", "IT/보안"];
 
-    const hydrateFromReservation = (r) => {
-        if (!r) return;
+  const hydrateFromReservation = (r) => {
+    if (!r) return;
 
-        setName(r.name ?? "");
-        setCount(Number(r.count ?? 4));
-        setClassType(r.classType ?? null);
+    setName(r.name ?? "");
+    setCount(Number(r.count ?? 4));
+    setClassType(r.classType ?? null);
 
-        const rawPin = String(r.pin ?? r.password ?? "")
-            .replace(/\D/g, "")
-            .slice(0, 4);
+    const rawPin = String(r.pin ?? r.password ?? "")
+      .replace(/\D/g, "")
+      .slice(0, 4);
 
-        setPin([rawPin[0] ?? "", rawPin[1] ?? "", rawPin[2] ?? "", rawPin[3] ?? ""]);
+    setPin([
+      rawPin[0] ?? "",
+      rawPin[1] ?? "",
+      rawPin[2] ?? "",
+      rawPin[3] ?? "",
+    ]);
+  };
+
+  useEffect(() => {
+    hydrateFromReservation(reservation);
+  }, [reservation]);
+
+  // ✅ 언마운트/닫기 전에 타이머 정리
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+    };
+  }, []);
+
+  const handlePinChange = (idx, value) => {
+    const digit = value.replace(/\D/g, "").slice(-1);
+    const next = [...pin];
+    next[idx] = digit;
+    setPin(next);
+
+    if (digit && idx < 3) pinRefs.current[idx + 1]?.focus();
+  };
+
+  const handlePinKeyDown = (idx, e) => {
+    if (e.key !== "Backspace") return;
+
+    if (pin[idx]) {
+      const next = [...pin];
+      next[idx] = "";
+      setPin(next);
+      return;
+    }
+
+    if (idx > 0) {
+      pinRefs.current[idx - 1]?.focus();
+      const next = [...pin];
+      next[idx - 1] = "";
+      setPin(next);
+    }
+  };
+
+  const handlePinPaste = (e) => {
+    e.preventDefault();
+
+    const text = (e.clipboardData.getData("text") || "")
+      .replace(/\D/g, "")
+      .slice(0, 4);
+
+    if (!text) return;
+
+    const next = ["", "", "", ""];
+    for (let i = 0; i < text.length; i++) next[i] = text[i];
+    setPin(next);
+
+    const focusIndex = Math.min(text.length, 4) - 1;
+    pinRefs.current[focusIndex]?.focus();
+  };
+
+  const canSubmit =
+    name.trim().length > 0 && !!classType && pin.every((x) => x !== "");
+
+  // ✅ 수정하기(저장) + 성공 토스트 띄우고 자동 닫기
+  const handleSave = async () => {
+    if (!canSubmit || isSaving) return;
+
+    const payload = {
+      ...reservation,
+      name: name.trim(),
+      count,
+      classType,
+      pin: pin.join(""),
     };
 
-    useEffect(() => {
-        hydrateFromReservation(reservation);
-    }, [reservation]);
+    try {
+      setIsSaving(true);
+      await onUpdate?.(payload);
 
-    // ✅ 언마운트/닫기 전에 타이머 정리
-    useEffect(() => {
-        return () => {
-            if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
-        };
-    }, []);
+      // ✅ "저장되었습니다" 보여주기
+      setSavedToast(true);
 
-    const handlePinChange = (idx, value) => {
-        const digit = value.replace(/\D/g, "").slice(-1);
-        const next = [...pin];
-        next[idx] = digit;
-        setPin(next);
-
-        if (digit && idx < 3) pinRefs.current[idx + 1]?.focus();
-    };
-
-    const handlePinKeyDown = (idx, e) => {
-        if (e.key !== "Backspace") return;
-
-        if (pin[idx]) {
-            const next = [...pin];
-            next[idx] = "";
-            setPin(next);
-            return;
-        }
-
-        if (idx > 0) {
-            pinRefs.current[idx - 1]?.focus();
-            const next = [...pin];
-            next[idx - 1] = "";
-            setPin(next);
-        }
-    };
-
-    const handlePinPaste = (e) => {
-        e.preventDefault();
-
-        const text = (e.clipboardData.getData("text") || "")
-            .replace(/\D/g, "")
-            .slice(0, 4);
-
-        if (!text) return;
-
-        const next = ["", "", "", ""];
-        for (let i = 0; i < text.length; i++) next[i] = text[i];
-        setPin(next);
-
-        const focusIndex = Math.min(text.length, 4) - 1;
-        pinRefs.current[focusIndex]?.focus();
-    };
-
-    const canSubmit =
-        name.trim().length > 0 &&
-        !!classType &&
-        pin.every((x) => x !== "");
-
-    // ✅ 수정하기(저장) + 성공 토스트 띄우고 자동 닫기
-    const handleSave = async () => {
-        if (!canSubmit || isSaving) return;
-
-        const payload = {
-            ...reservation,
-            name: name.trim(),
-            count,
-            classType,
-            pin: pin.join(""),
-        };
-
-        try {
-            setIsSaving(true);
-            await onUpdate?.(payload);
-
-            // ✅ "저장되었습니다" 보여주기
-            setSavedToast(true);
-
-            // ✅ 1.2초 뒤 자동 닫기 (원하면 1500으로 바꿔도 됨)
-            if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
-            closeTimerRef.current = setTimeout(() => {
-                onClose?.();
-            }, 1200);
-        } catch (e) {
-            alert("수정에 실패했어요. 다시 시도해주세요.");
-        } finally {
-            setIsSaving(false);
-        }
-    };
-
-    // ✅ 예약 취소
-    const handleCancelReservation = async () => {
-        if (isSaving) return;
-
-        const ok = window.confirm("정말 예약을 취소할까요? (되돌릴 수 없어요)");
-        if (!ok) return;
-
-        await onCancel?.({
-            ...reservation,
-            name: name.trim(),
-            count,
-            classType,
-            pin: pin.join(""),
-        });
-
+      // ✅ 1.2초 뒤 자동 닫기 (원하면 1500으로 바꿔도 됨)
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = setTimeout(() => {
         onClose?.();
-    };
+      }, 1200);
+    } catch (e) {
+      alert("수정에 실패했어요. 다시 시도해주세요.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
 
-    return (
-        <Modal type="center" onClose={onClose}>
-            {/* ✅ 저장 토스트 (모달 위에 살짝 뜨는 느낌) */}
-            {savedToast && <div className="toast-success">저장되었습니다.</div>}
+  // ✅ 예약 취소
+  const handleCancelReservation = async () => {
+    if (isSaving) return;
 
-            {/* 헤더 */}
-            <div className="form-header">
-                <h2 className="form-title">예약 내역</h2>
+    const ok = window.confirm("정말 예약을 취소할까요? (되돌릴 수 없어요)");
+    if (!ok) return;
+
+    await onCancel?.({
+      ...reservation,
+      name: name.trim(),
+      count,
+      classType,
+      pin: pin.join(""),
+    });
+
+    onClose?.();
+  };
+
+  return (
+    <Modal type="center" onClose={onClose}>
+      {/* ✅ 저장 토스트 (모달 위에 살짝 뜨는 느낌) */}
+      {savedToast && <div className="toast-success">저장되었습니다.</div>}
+
+      {/* 헤더 */}
+      <div className="form-header">
+        <h2 className="form-title">예약 내역</h2>
+      </div>
+
+      {/* 상단 예약 정보 */}
+      {(reservation?.date || reservation?.time || reservation?.room) && (
+        <div className="meta-chips">
+          {reservation?.date && (
+            <div className="meta-chip2">
+              <span className="meta-ico">📅</span>
+              <span className="meta-txt">{reservation.date}</span>
             </div>
-
-            {/* 상단 예약 정보 */}
-            {(reservation?.date || reservation?.time || reservation?.room) && (
-                <div className="meta-chips">
-                    {reservation?.date && (
-                        <div className="meta-chip2">
-                            <span className="meta-ico">📅</span>
-                            <span className="meta-txt">{reservation.date}</span>
-                        </div>
-                    )}
-                    <div className="meta-chips-div">
-                        {reservation?.time && (
-                            <div className="meta-chip">
-                                <span className="meta-ico">⏰</span>
-                                <span className="meta-txt">{reservation.time}</span>
-                            </div>
-                        )}
-                        {reservation?.room && (
-                            <div className="meta-chip">
-                                <span className="meta-ico">🏢</span>
-                                <span className="meta-txt">{reservation.room}</span>
-                            </div>
-                        )}
-                    </div>
-
-                </div>
+          )}
+          <div className="meta-chips-div">
+            {reservation?.time && (
+              <div className="meta-chip">
+                <span className="meta-ico">⏰</span>
+                <span className="meta-txt">{reservation.time}</span>
+              </div>
             )}
+            {reservation?.room && (
+              <div className="meta-chip">
+                <span className="meta-ico">🏢</span>
+                <span className="meta-txt">{reservation.room}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
-            <label className="form-label">예약자</label>
-            <input
-                className="form-input yellow"
-                placeholder="예약자 명을 입력해 주세요."
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                disabled={isSaving}
-            />
+      <label className="form-label">예약자</label>
+      <input
+        className="form-input yellow"
+        placeholder="예약자 명을 입력해 주세요."
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        disabled={isSaving}
+      />
 
-            <div className="people-group">
-                <span className="row-label">인원 수</span>
-                <div className="counter">
-                    <button type="button" onClick={() => setCount(Math.max(2, count - 1))} disabled={count <= 2 || isSaving}>−</button>
-                    <span>{count}명</span>
-                    <button type="button" onClick={() => setCount(count + 1)} disabled={isSaving}>＋</button>
-                </div>
-            </div>
+      <div className="people-group">
+        <span className="row-label">인원 수</span>
+        <div className="counter">
+          <button
+            type="button"
+            onClick={() => setCount(Math.max(2, count - 1))}
+            disabled={count <= 2 || isSaving}
+          >
+            −
+          </button>
+          <span>{count}명</span>
+          <button
+            type="button"
+            onClick={() => setCount(count + 1)}
+            disabled={isSaving}
+          >
+            ＋
+          </button>
+        </div>
+      </div>
 
-            <label className="form-label">해당 반</label>
-            <div className="class-group">
-                {classes.map((c) => (
-                    <button
-                        type="button"
-                        key={c}
-                        className={`class-btn ${classType === c ? "selected" : ""}`}
-                        onClick={() => setClassType(c)}
-                        disabled={isSaving}
-                    >
-                        {c}
-                    </button>
-                ))}
-            </div>
+      <label className="form-label">해당 반</label>
+      <div className="class-group">
+        {classes.map((c) => (
+          <button
+            type="button"
+            key={c}
+            className={`class-btn ${classType === c ? "selected" : ""}`}
+            onClick={() => setClassType(c)}
+            disabled={isSaving}
+          >
+            {c}
+          </button>
+        ))}
+      </div>
 
-            {/* 임시비밀번호 불필요 판단 */}
-            {/* <label className="form-label">예약 조회용 임시 비밀번호</label>
+      {/* 임시비밀번호 불필요 판단 */}
+      {/* <label className="form-label">예약 조회용 임시 비밀번호</label>
             <div className="pin-row" onPaste={handlePinPaste}>
                 {pin.map((v, i) => (
                     <input
@@ -233,23 +252,38 @@ const ReservationDetailModal = ({ reservation, onClose, onUpdate, onCancel }) =>
                 ))}
             </div> */}
 
-            <div className="form-divider" />
+      <div className="form-divider" />
 
-            <div className="form-actions">
-                <button type="button" className="form-submit danger" onClick={handleCancelReservation} disabled={!onCancel || isSaving}>
-                    예약 취소
-                </button>
+      <div className="form-actions">
+        <button
+          type="button"
+          className="form-submit danger"
+          onClick={handleCancelReservation}
+          disabled={!onCancel || isSaving}
+        >
+          예약 취소
+        </button>
 
-                <button type="button" className="form-submit secondary" onClick={onClose} disabled={isSaving}>
-                    나가기
-                </button>
+        <button
+          type="button"
+          className="form-submit secondary"
+          onClick={onClose}
+          disabled={isSaving}
+        >
+          나가기
+        </button>
 
-                <button type="button" className="form-submit" onClick={handleSave} disabled={!canSubmit || isSaving}>
-                    {isSaving ? "저장중..." : "수정하기"}
-                </button>
-            </div>
-        </Modal>
-    );
+        <button
+          type="button"
+          className="form-submit"
+          onClick={handleSave}
+          disabled={!canSubmit || isSaving}
+        >
+          {isSaving ? "저장중..." : "수정하기"}
+        </button>
+      </div>
+    </Modal>
+  );
 };
 
 export default ReservationDetailModal;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -87,6 +87,10 @@ const Home = () => {
   const [step, setStep] = useState("TIME"); // TIME | ROOM
   const [modal, setModal] = useState(null); // null | CONFIRM | FORM | CHECK | ADMIN
 
+  // 관리자용 토큰 (AdminModal 전달용도)
+  const [openAdmin, setOpenAdmin] = useState(false);
+  const [adminToken, setAdminToken] = useState(null);
+
   // null이면 "예약 확정"
   // 값이 있으면 "예약 수정"
   const [editingTarget, setEditingTarget] = useState(null);
@@ -107,6 +111,11 @@ const Home = () => {
   const [roomStatusLoading, setRoomStatusLoading] = useState(false);
 
   const SELECT_FEEDBACK_MS = 350;
+
+  const handleAdminForceCancel = async (payload) => {
+    // TODO: adminForceDelete API 연결
+    setOpenAdmin(false);
+  };
 
   useEffect(() => {
     const shouldRefresh = modal === "CONFIRM" || modal === "FORM";
@@ -457,21 +466,6 @@ const Home = () => {
           <button className="history-btn" onClick={() => setModal("CHECK")}>
             예약 내역
           </button>
-
-          {/* 임시 관리자 버튼 */}
-          <button className="admin-btn" onClick={() => setModal("ADMIN")}>
-            (임시) 관리자
-          </button>
-          {modal === "ADMIN" && (
-            <AdminModal
-              open={true}
-              onClose={() => setModal(null)}
-              onForceCancel={(payload) => {
-                console.log("강제취소", payload);
-                setModal(null);
-              }}
-            />
-          )}
         </div>
       </header>
 
@@ -485,11 +479,19 @@ const Home = () => {
           </p>
 
           <div className="notice-box">
-            <span>· 최대 2타임 ·</span>
-            <span className="notice-box-span2">
-              10시 전 프로젝트 진행 과정 우선
-            </span>
-            <span className="notice-icon">ⓘ</span>
+            <div>
+              <span className="notice-icon">ⓘ</span>
+              <span style={{ marginLeft: "8px" }}>회의실 이용 안내</span>
+            </div>
+
+            <div className="notice-box-div">
+              <span className="notice-span">· 프로젝트 진행 과정 ~10:00까지 예약 우선 작성</span>
+              <span className="notice-span">· 최대 2타임 까지만 예약 가능</span>
+              <span className="notice-span">· 오전 10시 이후부터는 모든 과정 예약 가능</span>
+              <span className="notice-span">· 회의실 예약은 당일 작성만 가능</span>
+              <span className="notice-span">· 회의실 사용 후 정리정돈 및 예약 내용 지우기</span>
+              <span className="notice-span">· 예약 취소는 우측 상단 '에약 내역' 에서 가능</span>
+            </div>
           </div>
         </section>
 
@@ -567,7 +569,15 @@ const Home = () => {
         )}
 
         {modal === "CHECK" && (
-          <CheckModal onClose={() => setModal(null)} onDelete={handleDelete} />
+          <CheckModal
+            onClose={() => setModal(null)}
+            onDelete={handleDelete}
+            onAdmin={(token) => {
+              setModal(null); // (선택) 체크 모달 닫고
+              setAdminToken(token); // 토큰 저장
+              setOpenAdmin(true); // 관리자 모달 열기
+            }}
+          />
         )}
 
         {modal === "DONE" && (
@@ -583,6 +593,13 @@ const Home = () => {
             </div>
           </Modal>
         )}
+
+        <AdminModal
+          open={openAdmin}
+          token={adminToken}
+          onClose={() => setOpenAdmin(false)}
+          onForceCancel={handleAdminForceCancel}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
1. 관리자 페이지 연동 
- 상단 관리자 임시 버튼 제거  / 예약 내역 -> 서버 환경 변수에 넣어둔 이름/패스워드 입력 시 관리자 modal 열리게끔

2. 관리자 API 연동
- 활용 가능한 비동기 함수 추가  (adminLogin, adminReadAll, adminForceDelete, adminReadRoom)

3. CSS 수정